### PR TITLE
Fix CSRF origin error on Railway

### DIFF
--- a/project_django/settings.py
+++ b/project_django/settings.py
@@ -148,3 +148,8 @@ STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Trying to fix CSRF origin checking error
+# https://forum.djangoproject.com/t/deploy-a-django-project-on-railway-how-to-fix-the-csrf-verification-failed/16832/2
+if not DEBUG:
+    CSRF_TRUSTED_ORIGINS = ["https://e-waste-bank.up.railway.app"]


### PR DESCRIPTION
As per https://forum.djangoproject.com/t/deploy-a-django-project-on-railway-how-to-fix-the-csrf-verification-failed/16832

I think it has something to do with the internal architecture of Railway (and how its different with Heroku's), but more investigation is needed